### PR TITLE
Add simple poll command

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -28,6 +28,10 @@
             el.outerHTML = message.html;
             el.scrollIntoView();
 
+            if (message.message.startsWith("!")) {
+                handle_command(message);
+            }
+
             while (main.children.length > 100) {
                 main.removeChild(main.firstChild);
             }
@@ -44,3 +48,125 @@
         setTimeout(function () { reconnect(); }, 3000);
     });
 })();
+
+var active_poll = null;
+const poll_ui = document.getElementById("poll-ui");
+
+class poll {
+    constructor(question, multi_vote, options) {
+        this.question = question;
+        this.options = options;
+        this.votes = [];
+        this.voters = [];
+        this.multi_vote = multi_vote;
+        this.total_votes = 0;
+
+        for (let i = 0; i < this.options.length; i++) {
+            this.votes.push(0);
+        }
+
+        this.update();
+        poll_ui.style.display = "block";
+        poll_ui.classList.remove("fade-out");
+        poll_ui.classList.add("fade-in");
+
+        this.end_timeout = setTimeout(() => {
+            this.end_poll();
+            active_poll = null;
+        }, 1000 * 120); // default poll duration of 2 minutes
+    }
+
+    end_poll() {
+        poll_ui.classList.remove("fade-in");
+        poll_ui.classList.add("fade-out");
+        clearTimeout(this.end_timeout);
+    }
+
+    update() {
+        let participants = this.voters.length;
+        let html = `<strong>${this.question}</strong><br><small>${participants} participants</small><ul>`;
+        for (let i = 0; i < this.options.length; i++) {
+            let percentage = 0;
+            if (this.total_votes > 0) {
+                percentage = (this.votes[i] / this.total_votes) * 100;
+                percentage = percentage.toFixed(2);
+            }
+            html += `<li>!vote ${i + 1}: ${this.options[i]} - ${this.votes[i]} (${percentage}%)</li>`;
+        }
+
+        html += "</ul><small>use !vote [number] to vote</small>";
+
+        poll_ui.innerHTML = html;
+    }
+
+    handle_vote_message(data) {
+        // check if user has already voted
+        if (active_poll.voters.includes(data.username))
+            return;
+
+        let args = data.message.replace("!vote", "").trim();
+        let result = false;
+        if (this.multi_vote) {
+            let votes = args.split(" ");
+            // remove duplicates
+            votes = [...new Set(votes)];
+
+            for (let i = 0; i < votes.length; i++)
+                result |= this.handle_vote(votes[i]);
+        } else {
+            result = this.handle_vote(args);
+        }
+
+        if (result) {
+            this.voters.push(data.username);
+            this.update();
+        }
+    }
+
+    handle_vote(vote_index) {
+        if (isNaN(vote_index))
+            return false;
+
+        let i = parseInt(vote_index) - 1;
+
+        if (i < 0 || i > this.options.length)
+            return false;
+
+        this.votes[i]++;
+        this.total_votes++;
+        return true;
+    }
+}
+
+function handle_command(message) {
+    let msg = message.message;
+    const is_admin = message.username === "madattheinternet";
+
+    if (msg.startsWith("!poll") && is_admin) {
+        msg = msg.replace("!poll", "").trim();
+        let parts = msg.split(";");
+        parts = parts.filter(el => el.length != 0);
+        if (parts.length < 3)
+            return;
+        active_poll = new poll(parts[0], false, parts.slice(1));
+    }
+    else if (msg.startsWith("!multipoll") && is_admin) {
+        msg = msg.replace("!multipoll", "").trim();
+        let parts = msg.split(";");
+        parts = parts.filter(el => el.length != 0);
+        if (parts.length < 3)
+            return;
+        active_poll = new poll(parts[0], true, parts.slice(1));
+    }
+    else if (msg.startsWith("!endpoll") && is_admin) {
+        if (active_poll !== null)
+            active_poll.end_poll();
+    }
+
+    else if (msg.startsWith("!vote")) {
+        if (active_poll === null)
+            return;
+
+        active_poll.handle_vote_message(message);
+    }
+}

--- a/public/style.css
+++ b/public/style.css
@@ -115,17 +115,73 @@ main {
 
 .msg-text {
     word-wrap: break-word;
-    vertical-align: bottom;;
+    vertical-align: bottom;
 }
-    .msg-text img {
-        max-height: 1em;
-        vertical-align: top;
+
+.msg-text img {
+    max-height: 1em;
+    vertical-align: top;
+}
+
+.msg-text a {
+    color: var(--msg-url, #ccc);
+    font-weight: normal;
+    text-decoration: none;
+}
+
+#poll-ui {
+    background: var(--msg-bg, rgba(11, 11, 11, 0.95));
+    color: var(--msg-url, #ccc);
+    position: absolute;
+    font-family: "Open Sans";
+    width: 100%;
+    padding: 0.5em;
+    display: none;
+    padding: 0.5em 0.8em 1em 0.8em;
+    border-radius: 0 0 0.8em 0.8em;
+    box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.5);
+}
+
+#poll-ui.fade-in {
+    animation: fade-in 0.5s ease-in-out forwards;
+}
+
+#poll-ui.fade-out {
+    animation: fade-out 0.5s ease-in-out forwards;
+
+}
+
+@keyframes fade-in {
+    from {
+        display: block;
+        opacity: 0;
     }
-    .msg-text a {
-        color: var(--msg-url, #ccc);
-        font-weight: normal;
-        text-decoration: none;
+
+    to {
+        display: block;
+        opacity: 1;
     }
+}
+
+@keyframes fade-out {
+    from {
+        opacity: 1;
+    }
+
+    to {
+        opacity: 0;
+    }
+}
+
+#poll-ui ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0.5em;
+}
+
+#poll-ui li+li {
+    margin-top: 0.5em;
+}
 
 /*
 .msg::before {

--- a/public/style.css
+++ b/public/style.css
@@ -1,7 +1,9 @@
 * {
     box-sizing: border-box;
 }
-html, body {
+
+html,
+body {
     background: none;
     border: none;
     padding: 0;
@@ -10,6 +12,7 @@ html, body {
     width: 100vw;
     overflow: hidden;
 }
+
 main {
     display: flex;
     height: auto;
@@ -19,6 +22,7 @@ main {
     left: 0;
     right: 0;
 }
+
 .msg {
     display: flex;
     flex-direction: row;
@@ -38,12 +42,14 @@ main {
     line-height: 16px;
     color: var(--msg-fg, #ccc);
 }
-    .msg--b-owner {
-        border-color: gold;
-    }
-    .msg--b-staff {
-        border-color: red;
-    }
+
+.msg--b-owner {
+    border-color: gold;
+}
+
+.msg--b-staff {
+    border-color: red;
+}
 
 .msg-user {
     font-size: 90%;
@@ -52,21 +58,26 @@ main {
     margin-top: -4px;
     margin-bottom: 4px;
 }
-    .msg--b-sub .msg-user {
-        color: rgb(47, 141, 21);
-    }
-    .msg--b-mod .msg-user {
-        color: rgb(25, 124, 237);
-    }
-    .msg--b-verified .msg-user {
-        color: rgb(168, 13, 168);
-    }
-    .msg--b-staff .msg-user {
-        color: rgb(255, 52, 52);
-    }
-    .msg--b-owner .msg-user {
-        color: rgb(255, 215, 0);
-    }
+
+.msg--b-sub .msg-user {
+    color: rgb(47, 141, 21);
+}
+
+.msg--b-mod .msg-user {
+    color: rgb(25, 124, 237);
+}
+
+.msg--b-verified .msg-user {
+    color: rgb(168, 13, 168);
+}
+
+.msg--b-staff .msg-user {
+    color: rgb(255, 52, 52);
+}
+
+.msg--b-owner .msg-user {
+    color: rgb(255, 215, 0);
+}
 
 
 .msg-avatar {
@@ -78,6 +89,7 @@ main {
     background: var(--brand-color);
     border-color: var(--brand-color);
 }
+
 .msg-avatar-border {
     height: 2em;
     width: 2em;
@@ -86,32 +98,39 @@ main {
     overflow: hidden;
     flex-shrink: 0;
 }
-    .msg--p-Kick .msg-avatar,
-    .msg--p-Kick .msg-avatar-border {
-        --brand-color: transparent;
-        border-radius: 0;
-    }
-    .msg--p-Odysee .msg-avatar {
-        --brand-color: var(--odysee-brand, rgb(166, 10, 67, 1));
-        border-color: transparent;
-        background: none;
-    }
-    .msg--p-Odysee .msg-avatar-border {
-        background: linear-gradient(45deg, #ef1970 0%, #f23b5c 14%, #f77d35 45%, #fcad18 70%, #fecb07 89%, #ffd600 100%);
-    }
-    .msg--p-Rumble .msg-avatar {
-        --brand-color: var(--rumble-brand, rgba(133, 199, 66, 1));
-    }
-    .msg--p-YouTube .msg-avatar {
-        --brand-color: var(--youtube-brand, rgba(255, 0, 0, 1));
-    }
-    .msg--p-VK .msg-avatar {
-        --brand-color: var(--vk-brand, rgb(255, 43, 66, 1));
-    }
-    .msg--p-VK .msg-avatar-border {
-        /* drop shadow mimics the VK logo a bit. */
-        box-shadow: 2px 0px var(--vk--brand-shadow, rgb(0, 119, 255, 0.66));
-    }
+
+.msg--p-Kick .msg-avatar,
+.msg--p-Kick .msg-avatar-border {
+    --brand-color: transparent;
+    border-radius: 0;
+}
+
+.msg--p-Odysee .msg-avatar {
+    --brand-color: var(--odysee-brand, rgb(166, 10, 67, 1));
+    border-color: transparent;
+    background: none;
+}
+
+.msg--p-Odysee .msg-avatar-border {
+    background: linear-gradient(45deg, #ef1970 0%, #f23b5c 14%, #f77d35 45%, #fcad18 70%, #fecb07 89%, #ffd600 100%);
+}
+
+.msg--p-Rumble .msg-avatar {
+    --brand-color: var(--rumble-brand, rgba(133, 199, 66, 1));
+}
+
+.msg--p-YouTube .msg-avatar {
+    --brand-color: var(--youtube-brand, rgba(255, 0, 0, 1));
+}
+
+.msg--p-VK .msg-avatar {
+    --brand-color: var(--vk-brand, rgb(255, 43, 66, 1));
+}
+
+.msg--p-VK .msg-avatar-border {
+    /* drop shadow mimics the VK logo a bit. */
+    box-shadow: 2px 0px var(--vk--brand-shadow, rgb(0, 119, 255, 0.66));
+}
 
 .msg-text {
     word-wrap: break-word;
@@ -129,17 +148,66 @@ main {
     text-decoration: none;
 }
 
+#flyout {
+    position: absolute;
+    width: 100%;
+    font-family: "Open Sans";
+}
+
+#superchat-ui {
+    transition: all .2s ease-in-out;
+    width: 100%;
+    top: 0px;
+}
+
+#superchat-ui.slide-down {
+    animation: slide-down 0.5s ease-in-out forwards;
+}
+
+#superchat-ui.slide-up {
+    animation: slide-down 0.5s ease-in-out forwards;
+
+}
+
+.superchat {
+    width: 100%;
+    border-radius: 0.8em 0 0 0.8em;
+    background: var(--superchat-bg, rgba(92, 42, 42, 0.95));
+    animation-duration: 0.5s;
+    animation-name: slide-in;
+    margin-top: 0.5em;
+    overflow: hidden;
+}
+
+.superchat-message {
+    padding: 0.1em 0.1em 0.3em 0.5em;
+}
+
+.superchat-message>p {
+    margin: 0;
+}
+
+.superchat-timeout-bar {
+    height: 0.1em;
+    width: 100%;
+    background: var(--superchat-timeout-bar-bg, rgba(245, 160, 160, 0.986));
+    float: right;
+    right: 0;
+}
+
+#poll-ui,
+.superchat {
+    color: var(--msg-url, #ccc);
+    width: 100%;
+
+    box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.5);
+}
+
 #poll-ui {
     background: var(--msg-bg, rgba(11, 11, 11, 0.95));
-    color: var(--msg-url, #ccc);
-    position: absolute;
-    font-family: "Open Sans";
-    width: 100%;
-    padding: 0.5em;
     display: none;
     padding: 0.5em 0.8em 1em 0.8em;
     border-radius: 0 0 0.8em 0.8em;
-    box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.5);
 }
 
 #poll-ui.fade-in {
@@ -149,6 +217,28 @@ main {
 #poll-ui.fade-out {
     animation: fade-out 0.5s ease-in-out forwards;
 
+}
+
+@keyframes slide-down {
+    from {
+        position: absolute;
+    }
+
+    to {
+        position: relative;
+    }
+}
+
+@keyframes slide-in {
+    from {
+        margin-left: 100%;
+        width: 300%;
+    }
+
+    to {
+        margin-left: 0%;
+        width: 100%;
+    }
 }
 
 @keyframes fade-in {
@@ -170,6 +260,7 @@ main {
 
     to {
         opacity: 0;
+        display: none;
     }
 }
 
@@ -182,6 +273,7 @@ main {
 #poll-ui li+li {
     margin-top: 0.5em;
 }
+
 
 /*
 .msg::before {

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,11 @@
 </head>
 
 <body>
+
     <main></main>
+    <div id="poll-ui">
+
+    </div>
     <script type="text/javascript" src="/script.js"></script>
 </body>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,8 +10,11 @@
 <body>
 
     <main></main>
-    <div id="poll-ui">
-
+    <div id="flyout">
+        <div id="poll-ui">
+        </div>
+        <div id="superchat-ui">
+        </div>
     </div>
     <script type="text/javascript" src="/script.js"></script>
 </body>


### PR DESCRIPTION
Adds a simple poll command. I initially thought about handling commands on the server side, but two things kept me from doing so:

1. I fucking hate rust
2. This worked just as well

Basic functionality is:

- Run `!poll [question]; [option 1]; [option 2]; ...; [option n]`
- Users vote via `!vote [n]` i.e. `!vote 1` from any one of the supported platforms
- The poll will automatically end after two minutes or when `!endpoll` is used
- `!multipoll` instead of `!poll` can be used to create a poll that allows users to vote for multiple options with `!vote 1 4 2 ...`

Not the most elegant solution, but it works. Currently the user who can start and stop polls is hardcoded [here](https://github.com/cohlexyz/stream-nexus/blob/polls/public/script.js#L143) which should probably be configurable.

Screenshots:
![image](https://github.com/jaw-sh/stream-nexus/assets/142505474/e404b70e-071c-458f-ab8a-460c69090179)
![image](https://github.com/jaw-sh/stream-nexus/assets/142505474/d6274e43-ee17-48fd-b3c4-35ed1dae5084)
