### PR TITLE
Very basic persistence for super chats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.env
 /target
+super_chats.json


### PR DESCRIPTION
Backs up super chats to ./super_chats.json every time a new one is received. Will load them on next startup if the last modified time of the file is more recent than 15 minutes ago. Should assure that super chats can be recovered after a crash and prevent chats from an older session being loaded.

Not really the most elegant solution but it works. Closes #20 