### PR TITLE
Unescape poll command

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -311,10 +311,18 @@ class poll {
 }
 
 function handle_command(message) {
+    function unescape(escaped_string) {
+        const tmp_div = document.createElement("div");
+        tmp_div.innerHTML = escaped_string;
+        return tmp_div.textContent || tmp_div.innerText || "";
+    }
+
     // ignore non-commands, except if a vote is running so we can allow messages like "1" or "!2" to be counted as votes
     if (!message.message.startsWith("!") && active_poll === null)
         return false;
-    let msg = message.message;
+
+    // html escape codes use semicolons, so we need to unescape them otherwise the splitting will break
+    let msg = unescape(message.message);
     const is_admin = message.is_owner;
 
     if (msg.startsWith("!poll") && is_admin) {


### PR DESCRIPTION
The messages use html escape codes like `&#39;` which screws with the parsing of the command so we have to unescape them first. Using semicolons in polls will still break, though.

I guess we could at this point also move poll commands from being chat commands to proper messages like the way featured messages are handled, but I didn't want to make too many changes.

https://github.com/user-attachments/assets/0b0f9e7b-fbe2-4513-b28a-4ddd4f1ae0d2

