### PR TITLE
Added extra keyboard shortcuts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .claude/
 .vscode/
 *.code-workspace
+.idea/
 
 # Dependencies
 node_modules/


### PR DESCRIPTION
Added some more keyboard shortcuts for the Editor.

New Shortcuts:
    // Element Management:
    // - Ctrl+D: Duplicate selected element
    // - Ctrl+L: Toggle lock on selected element
    // - Tab/Shift+Tab: Cycle through elements
    // - Escape: Reset to first element

    // Layer Management:
    // - Ctrl+]: Bring forward one layer
    // - Ctrl+[: Send back one layer
    // - Ctrl+Shift+]: Bring to front
    // - Ctrl+Shift+[: Send to back

    // Positioning (handled in EditorCanvas):
    // - Arrow keys: Move 1px
    // - Shift+Arrow keys: Move 10px
    // - Ctrl+Arrow keys: Resize 1px
    // - Ctrl+Shift+Arrow keys: Resize 10px