### PR TITLE
Added grid snapping to elements and element to element snapping for t…

### DIFF
--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -77,6 +77,15 @@ function App() {
     const saveDebounceRef = useRef<NodeJS.Timeout | null>(null);
     const isUndoingRef = useRef(false);
 
+    // Grid settings
+    const [gridSettings, setGridSettings] = useState({
+        enabled: true,
+        size: 20, // pixels
+        visible: true,
+        snapThreshold: 10, // pixels
+        snapToElements: true,
+    });
+
     // Track current layout name to detect when switching layouts
     const currentLayoutNameRef = useRef<string | null>(null);
 
@@ -716,6 +725,8 @@ function App() {
                         canUndo={undoHistory.length > 0}
                         canRedo={redoHistory.length > 0}
                         onAddElement={handleAddElement}
+                        gridSettings={gridSettings}
+                        onGridSettingsChange={setGridSettings}
                     />
                     <div className="right-panels">
                         <LayerPanel

--- a/editor/src/components/EditorCanvas.tsx
+++ b/editor/src/components/EditorCanvas.tsx
@@ -592,19 +592,17 @@ export function EditorCanvas({
             const draggedBottom = newY + newHeight;
 
             // Check for snapping and set snappedElement if any snap occurs
-            const prevSnappedX = snappedX;
-            const prevSnappedY = snappedY;
             snapLineX = undefined;
             snapLineY = undefined;
 
             // Snap to left edge
-            if (Math.abs(newX - otherLeft) < threshold) { snappedX = otherLeft; snapLineX = otherLeft; console.log("1");}
+            if (Math.abs(newX - otherLeft) < threshold) { snappedX = otherLeft; snapLineX = otherLeft; }
             // Snap to right edge
-            if (Math.abs(newX - otherRight) < threshold) { snappedX = otherRight; snapLineX = otherRight; console.log("2"); }
+            if (Math.abs(newX - otherRight) < threshold) { snappedX = otherRight; snapLineX = otherRight; }
             // Snap dragged right edge to other left edge
-            if (Math.abs(draggedRight - otherLeft) < threshold) { snappedX = otherLeft - newWidth; snapLineX = otherLeft; console.log("3"); }
+            if (Math.abs(draggedRight - otherLeft) < threshold) { snappedX = otherLeft - newWidth; snapLineX = otherLeft; }
             // Snap dragged right edge to other right edge
-            if (Math.abs(draggedRight - otherRight) < threshold) { snappedX = otherRight - newWidth; snapLineX = otherRight; console.log("4"); }
+            if (Math.abs(draggedRight - otherRight) < threshold) { snappedX = otherRight - newWidth; snapLineX = otherRight; }
 
             // Snap to top edge
             if (Math.abs(newY - otherTop) < threshold) { snappedY = otherTop; snapLineY = otherTop; }

--- a/editor/src/styles.css
+++ b/editor/src/styles.css
@@ -977,3 +977,23 @@
         transform: translateY(5px);
     }
 }
+
+/* Grid settings in toolbar */
+.grid-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+}
+
+/* Snap highlight for elements being snapped to */
+.element-wrapper.snap-highlight {
+    box-shadow: 0 0 0 2px #00ff88 !important;
+    animation: snap-pulse 0.3s ease-in-out;
+}
+
+@keyframes snap-pulse {
+    0% { box-shadow: 0 0 0 2px #00ff88; }
+    50% { box-shadow: 0 0 0 4px rgba(0, 255, 136, 0.5); }
+    100% { box-shadow: 0 0 0 2px #00ff88; }
+}


### PR DESCRIPTION
Added grid snapping:
- When dragging an element, hold the shift key to snap to a grid. The grids size is changeable.
Added element to element snapping:
- When dragging an element, hold the shift + alt key to snap to other near by elements.


The element snapping guide line doesn't always display. It still snaps, but the line doesn't show. Couldn't figure that out but I figured its fine.  